### PR TITLE
Allow extending from custom modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ exports.default = babel => {
 
         // if not extends from UI5 class
         if (!isUI5Class(node.superClass.name, state.imports)) {
-          return;
+        //   return;
         }
 
         /**


### PR DESCRIPTION
Hi,
I tried to define a class that extends from my custom class, but I found that the compiled code just keeps the `class` keyword in it and is not transformed into es5 style.
What about enabling this feature? I think it is very useful.

For example:

Source code:
```typescript
// Person.ts
import BaseObject from "sap/ui/base/Object";
export default class Person extends BaseObject { }

// Student.ts
import Person from "./Person";
export default class Student extends Person { }
```

Expected output:
```js
// Student.js
sap.ui.define("test/Student", ["test/Person"], function (Person) {
  var _default = {};
  var Student = Person.extend("test.Student", {});
  _default = Object.assign(Student, _default);
  return _default;
})
```

Actual output:
```js
// Student.js
sap.ui.define("test/Student", ["test/Person"], function (Person) {
  var _default = {};

  class Student extends Person {}

  _default = Object.assign(Student, _default);
  return _default;
})
```